### PR TITLE
Additional Error Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Student_id,Password
 * npm i puppeteer
 * npm i csv-parser
 
+## Gotchas
+If your Mailing and Physical contacts for a student have different contact ID numbers then you will need to make sure the LoginID is unique for each of them. Otherwise you run into a duplicate ID error.
+
 ## Project Goals:
 - [x] Lots of Error Control
 - [x] Processing a CSV

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Student_id,Password
 403002345,Water!2345
 ````
 
+## CSV Error Output:
+````
+Student_id,Error Details
+403001234,"The Password must be at least 8 character(s) in length."
+````
+
 ## PowerShell Wrapper example your using your existing Encrypted Password:
 ````
 .\hacpassword.ps1 -username 0403cmillsap -studentID 403005966 -hacpassword "Testing 123234" -SetLoginIDasEmail -DoNotRequirePasswordChange

--- a/hacpassword.js
+++ b/hacpassword.js
@@ -57,6 +57,10 @@ if (process.argv.indexOf('-displayprogress') > 0) {
   var displayProgress = true
 }
 
+fs.writeFile('hac_errors.csv', "Student_id,Error Details\r\n", (err) => {
+  if (err) throw err;
+});
+
 // eSchool login
 (async () => {
   if (displayProgress) {
@@ -303,12 +307,22 @@ if (process.argv.indexOf('-displayprogress') > 0) {
                 let element = await stuPage.$('#error-list > li');
                 let value = await stuPage.evaluate(el => el.textContent, element);
                 console.log("Error:",value);
+
+                fs.appendFile('hac_errors.csv', StudentID + ',"' + value + '"\r\n', function (err) {
+                  if (err) throw err;
+                });
+
               }
 
               await stuPage.close();
 
             } catch(err) {
               console.log("Failed to update",StudentID,": ",err)
+              
+              fs.appendFile('hac_errors.csv', StudentID + ',Generic Error\r\n', function (err) {
+                if (err) throw err;
+              });
+
               //still need to close the window.
               await stuPage.close();
             }
@@ -324,7 +338,7 @@ if (process.argv.indexOf('-displayprogress') > 0) {
     }
 
   } catch(err) {
-    console.log('Failed to update password.')
+    console.log('Program crash.',err)
     process.exit(1)
   }
 

--- a/hacpassword.js
+++ b/hacpassword.js
@@ -62,7 +62,7 @@ if (process.argv.indexOf('-displayprogress') > 0) {
   if (displayProgress) {
     var browser = await puppeteer.launch({
       headless: false,
-      slowMo: 100
+      slowMo: 75
     });
   } else {
     var browser = await puppeteer.launch();
@@ -162,9 +162,12 @@ if (process.argv.indexOf('-displayprogress') > 0) {
 
       }
 
-      if (passwordChangeNotRequired) {
-        await page.click('#AddressOrContactDetail_Contact_MustChangePasswordNextLogin');
-      }
+      //If you have student password change disabled then you can't click this box.
+      try {
+        if (passwordChangeNotRequired) {
+          await page.click('#AddressOrContactDetail_Contact_MustChangePasswordNextLogin');
+        }
+      } catch {}
 
       await page.click('#pageOptions-option-save');
       await page.waitForTimeout(500);
@@ -277,9 +280,12 @@ if (process.argv.indexOf('-displayprogress') > 0) {
 
               } 
 
-              if (passwordChangeNotRequired) {
-                await stuPage.click('#AddressOrContactDetail_Contact_MustChangePasswordNextLogin');
-              }
+              //If you have student password change disabled then you can't click this box.
+              try {
+                if (passwordChangeNotRequired) {
+                  await stuPage.click('#AddressOrContactDetail_Contact_MustChangePasswordNextLogin');
+                }
+              } catch {}
 
               await stuPage.click('#pageOptions-option-save');
               await stuPage.waitForTimeout(1000);
@@ -303,6 +309,8 @@ if (process.argv.indexOf('-displayprogress') > 0) {
 
             } catch(err) {
               console.log("Failed to update",StudentID,": ",err)
+              //still need to close the window.
+              await stuPage.close();
             }
 
             //if we reached the end of the loop then close completely.

--- a/hacpassword.js
+++ b/hacpassword.js
@@ -192,6 +192,9 @@ if (process.argv.indexOf('-displayprogress') > 0) {
     } else {
       //csv file has been supplied. Lets do some crazy looping.
 
+      //close the original login page because of the timeout box.
+      await page.close();
+
       fs.createReadStream(csvPath)
       .pipe(csv())
       //.on('data', async (row) => {

--- a/hacpassword.ps1
+++ b/hacpassword.ps1
@@ -49,4 +49,9 @@ if ($DisplayProgress) {
     $nodeArguments += @('-displayprogress')
 }
 
-Start-Process -FilePath "node.exe" -ArgumentList $nodeArguments -NoNewWindow -Wait
+$process = Start-Process -FilePath "node.exe" -ArgumentList $nodeArguments -NoNewWindow -Wait -PassThru
+
+if ($process.ExitCode -ge 1) {
+    write-host "Failed to update passwords correctly."
+    exit(1)
+}


### PR DESCRIPTION
The powershell wrapper will now return an exit code if node crashes.

If processing a CSV and a single student update fails then it will be logged to hac_errors.csv.  This allows the hacpassword.js to not report an error, continue, but log the ones that fail so they can be dealt with afterwards.